### PR TITLE
Feat: Logging Enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 .DS_Store
 # ignore database files
 *.db
+# ignore log files
+*.log

--- a/project/techtrends/app.py
+++ b/project/techtrends/app.py
@@ -46,7 +46,6 @@ def get_db_connection_count():
         app.logger.error(f"Error: process exceeded {TIMEOUT}")
         db_connection_count = -1
     except sqlite3.OperationalError as e:
-        p2.kill()
         app.logger.error(f"Error: {e}")
         db_connection_count = -1
     return db_connection_count

--- a/project/techtrends/app.py
+++ b/project/techtrends/app.py
@@ -92,13 +92,16 @@ def index():
 def post(post_id):
     post = get_post(post_id)
     if post is None:
+        app.logger.info(f"Article with id \"{post_id}\" is not found!")
         return render_template('404.html'), 404
     else:
+        app.logger.info(f"Article \"{post['title']}\" retrieved!")
         return render_template('post.html', post=post)
 
 # Define the About Us page
 @app.route('/about')
 def about():
+    app.logger.info("About page retrieved!")
     return render_template('about.html')
 
 # Define the post creation functionality
@@ -117,6 +120,7 @@ def create():
             connection.commit()
             connection.close()
 
+            app.logger.info(f"New Article \"{title}\" created!")
             return redirect(url_for('index'))
 
     return render_template('create.html')
@@ -134,17 +138,22 @@ def healthz():
     res = dict()
     status_code = 200
     try:
+        app.logger.debug("Openning test database connection")
         conn = sqlite3.connect(DATABASE_FILE)
         cur = conn.cursor()
         # simple test query
+        app.logger.debug("Executing test query")
         cur.execute('SELECT 1').fetchone()
+        app.logger.debug("Test query is successful")
     except Exception as e:
         result = 'NOT OK - unhealthy'
         status_code = 500
         res['reason'] = str(e)
+        app.logger.error(f"Error: failed healthcheck, {str(e)}")
     else:
         result = 'OK - healthy'
     finally:
+        app.logger.debug("Closing database connection")
         conn.close()
         res['result'] = result
         return app.response_class(

--- a/project/techtrends/app.py
+++ b/project/techtrends/app.py
@@ -3,6 +3,7 @@ import sqlite3
 from flask import Flask, jsonify, json, render_template, request, url_for, redirect, flash
 from werkzeug.exceptions import abort
 import subprocess
+import logging
 
 DATABASE_FILE = 'database.db'
 PORT = '3111'
@@ -186,4 +187,7 @@ def metrics():
 
 # start the application on port 3111
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG,
+                        format="%(levelname)s:%(name)s:%(asctime)s, %(message)s",
+                        datefmt='%d/%m/%y, %H:%M:%S')
     app.run(host='0.0.0.0', port=PORT)


### PR DESCRIPTION
`TechTrends` is now more insightful by adding a couple of logging lines within `app.py`. A sample is shown below:

```shell
 * Serving Flask app 'app' (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
WARNING:werkzeug:25/01/23, 20:09:11,  * Running on all addresses.
   WARNING: This is a development server. Do not use it in a production deployment.
INFO:werkzeug:25/01/23, 20:09:11,  * Running on http://192.168.1.4:3111/ (Press CTRL+C to quit)
INFO:werkzeug:25/01/23, 20:09:31, 192.168.1.4 - - [25/Jan/2023 20:09:31] "GET / HTTP/1.1" 200 -
INFO:werkzeug:25/01/23, 20:09:31, 192.168.1.4 - - [25/Jan/2023 20:09:31] "GET /static/css/main.css HTTP/1.1" 304 -
INFO:app:25/01/23, 20:09:37, Article "2020 CNCF Annual Report" retrieved!
INFO:werkzeug:25/01/23, 20:09:37, 192.168.1.4 - - [25/Jan/2023 20:09:37] "GET /1 HTTP/1.1" 200 -
INFO:werkzeug:25/01/23, 20:09:37, 192.168.1.4 - - [25/Jan/2023 20:09:37] "GET /static/css/main.css HTTP/1.1" 304 -
INFO:app:25/01/23, 20:09:40, About page retrieved!
INFO:werkzeug:25/01/23, 20:09:40, 192.168.1.4 - - [25/Jan/2023 20:09:40] "GET /about HTTP/1.1" 200 -
INFO:werkzeug:25/01/23, 20:09:40, 192.168.1.4 - - [25/Jan/2023 20:09:40] "GET /static/css/main.css HTTP/1.1" 304 -
INFO:werkzeug:25/01/23, 20:09:44, 192.168.1.4 - - [25/Jan/2023 20:09:44] "GET /create HTTP/1.1" 200 -
INFO:werkzeug:25/01/23, 20:09:44, 192.168.1.4 - - [25/Jan/2023 20:09:44] "GET /static/css/main.css HTTP/1.1" 304 -
INFO:app:25/01/23, 20:10:07, New Article "Argo CD" created!
INFO:werkzeug:25/01/23, 20:10:07, 192.168.1.4 - - [25/Jan/2023 20:10:07] "POST /create HTTP/1.1" 302 -
INFO:werkzeug:25/01/23, 20:10:07, 192.168.1.4 - - [25/Jan/2023 20:10:07] "GET / HTTP/1.1" 200 -
INFO:werkzeug:25/01/23, 20:10:07, 192.168.1.4 - - [25/Jan/2023 20:10:07] "GET /static/css/main.css HTTP/1.1" 304 -
DEBUG:app:25/01/23, 20:10:14, db_connection_count: 0
DEBUG:app:25/01/23, 20:10:14, post_count: 7
DEBUG:app:25/01/23, 20:10:14, metrics: {"db_connection_count": 0, "post_count": 7}
INFO:werkzeug:25/01/23, 20:10:14, 192.168.1.4 - - [25/Jan/2023 20:10:14] "GET /metrics HTTP/1.1" 200 -
DEBUG:app:25/01/23, 20:10:18, Openning test database connection
DEBUG:app:25/01/23, 20:10:18, Executing test query
DEBUG:app:25/01/23, 20:10:18, Test query is successful
DEBUG:app:25/01/23, 20:10:18, Closing database connection
INFO:werkzeug:25/01/23, 20:10:18, 192.168.1.4 - - [25/Jan/2023 20:10:18] "GET /healthz HTTP/1.1" 200 -
```

What has changed?

- [x] Set `logging.basicConfig()`.
- [x] Set logging level to `DEBUG`.
- [x] Set logging record format to `"%(levelname)s:%(name)s:%(asctime)s, %(message)s"`.
- [x] Set datefmt to `%d/%m/%y, %H:%M:%S`.
- [x] Removed potential error line in `get_db_connection_count()` `sqlite3.OperationalError` Exception.