### PR TITLE
Feat: TechTrends CI Workflow

### DIFF
--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - main
-      # TODO: Remove when development is done
-      - feat/techtrends-ci-workflow
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 # ensure that only a single job or workflow using the same concurrency group will run at a time
 concurrency:

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -15,6 +15,9 @@ concurrency:
   # cancel previously running builds in a PR on new pushes
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+# set default permissions granted to the GITHUB_TOKEN to read only to follow least privilege principle
+permissions: read-all
+
 jobs:
   build:
     timeout-minutes: 30

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# ensure that only a single job or workflow using the same concurrency group will run at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # cancel previously running builds in a PR on new pushes
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build:
     timeout-minutes: 30

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -2,7 +2,10 @@ name: TechTrends - Package with Docker
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # TODO: Remove when development is done
+      - feat/techtrends-ci-workflow
   pull_request:
     branches: [main]
 

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -1,0 +1,32 @@
+name: TechTrends - Package with Docker
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./project
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/techtrends:latest

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -3,6 +3,8 @@ name: TechTrends - Package with Docker
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/techtrends-dockerhub.yml
+++ b/.github/workflows/techtrends-dockerhub.yml
@@ -20,7 +20,8 @@ permissions: read-all
 
 jobs:
   build:
-    timeout-minutes: 30
+    # set timeout to 15 mins max to decrease hanging jobs issues, default is 6 Hrs
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
What has changed?

- [x] Added `DOCKERHUB_USERNAME` & `DOCKERHUB_TOKEN` repository secrets.
- [x] Created `TechTrends - Package with Docker` workflow.
- [x] Configured a `${{ github.workflow }}-${{ github.ref }}` concurrency group strategy.
- [x] Trigger CI on PRs to `main` branch.
- [x] Set `GITHUB_TOKEN` default permissions to `read-only `.
- [x] Set `timeout-minutes` to `15`.

Since the `Dockerfile` is optimized, the CI took only `46s` and the image size on Dockerhub is `64.25 MB` only!