### PR TITLE
Fix: Modify techtrends Helm Chart image name

### DIFF
--- a/project/helm/values.yaml
+++ b/project/helm/values.yaml
@@ -3,7 +3,7 @@ namespace: sandbox
 replicaCount: 1
 
 image:
-  repository: shehabeldeen/nginx
+  repository: shehabeldeen/techtrends
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- [x] Fixed `techtrends` Helm Chart image name from shehabeldeen/`nginx`:latest to shehabeldeen/`techtrends`:latest