### PR TITLE
Feat: readinessProbe & livenessProbe Enhancement

### DIFF
--- a/project/helm/templates/deploy.yaml
+++ b/project/helm/templates/deploy.yaml
@@ -36,9 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbePath }}
-              port: {{ .Values.containerPort }}
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port | default .Values.containerPort }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbePath }}
-              port: {{ .Values.containerPort }}
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port | default .Values.containerPort }}

--- a/project/helm/values.yaml
+++ b/project/helm/values.yaml
@@ -24,7 +24,11 @@ resources:
 containerPort: 3111
  
 # checks on containerPort
-livenessProbePath: /healthz
+livenessProbe:
+  path: /healthz
+  port: ""
 
 # checks on containerPort
-readinessProbePath: /healthz
+readinessProbe:
+  path: /healthz
+  port: ""


### PR DESCRIPTION
`techtrends` Helm chart `readinessProbe` & `livenessProbe` better management

```yaml
# values.yaml
...
# checks on containerPort
livenessProbe:
  path: /healthz
  port: ""

# checks on containerPort
readinessProbe:
  path: /healthz
  port: ""
```

```yaml
# templates/deploy.yaml
...
          ...
          livenessProbe:
            httpGet:
              path: {{ .Values.livenessProbe.path }}
              port: {{ .Values.livenessProbe.port | default .Values.containerPort }}
          readinessProbe:
            httpGet:
              path: {{ .Values.readinessProbe.path }}
              port: {{ .Values.readinessProbe.port | default .Values.containerPort }}
```

What has changed?

- [x] set `livenessProbe.port` & `readinessProbe` to `containerPort` if no value given